### PR TITLE
Complete responses in general blob operations

### DIFF
--- a/appendblob_test.go
+++ b/appendblob_test.go
@@ -20,7 +20,7 @@ func (s *AppendBlobSuite) TestPutAppendBlob(c *chk.C) {
 	c.Assert(b.PutAppendBlob(nil), chk.IsNil)
 
 	// Verify
-	err := b.GetProperties(nil)
+	_, err := b.GetProperties(nil)
 	c.Assert(err, chk.IsNil)
 	c.Assert(b.Properties.ContentLength, chk.Equals, int64(0))
 	c.Assert(b.Properties.BlobType, chk.Equals, BlobTypeAppend)
@@ -50,8 +50,8 @@ func (s *AppendBlobSuite) TestPutAppendBlobAppendBlocks(c *chk.C) {
 	}
 	out, err := b.GetRange(&options)
 	c.Assert(err, chk.IsNil)
-	defer out.Close()
-	blobContents, err := ioutil.ReadAll(out)
+	defer out.Body.Close()
+	blobContents, err := ioutil.ReadAll(out.Body)
 	c.Assert(err, chk.IsNil)
 	c.Assert(blobContents, chk.DeepEquals, chunk1)
 
@@ -62,8 +62,8 @@ func (s *AppendBlobSuite) TestPutAppendBlobAppendBlocks(c *chk.C) {
 	options.Range.End = uint64(len(chunk1) + len(chunk2) - 1)
 	out, err = b.GetRange(&options)
 	c.Assert(err, chk.IsNil)
-	defer out.Close()
-	blobContents, err = ioutil.ReadAll(out)
+	defer out.Body.Close()
+	blobContents, err = ioutil.ReadAll(out.Body)
 	c.Assert(err, chk.IsNil)
 	c.Assert(blobContents, chk.DeepEquals, append(chunk1, chunk2...))
 }
@@ -78,7 +78,7 @@ func (s *StorageBlobSuite) TestPutAppendBlobSpecialChars(c *chk.C) {
 	c.Assert(b.PutAppendBlob(nil), chk.IsNil)
 
 	// Verify metadata
-	err := b.GetProperties(nil)
+	_, err := b.GetProperties(nil)
 	c.Assert(err, chk.IsNil)
 	c.Assert(b.Properties.ContentLength, chk.Equals, int64(0))
 	c.Assert(b.Properties.BlobType, chk.Equals, BlobTypeAppend)
@@ -98,8 +98,8 @@ func (s *StorageBlobSuite) TestPutAppendBlobSpecialChars(c *chk.C) {
 	}
 	out, err := b.GetRange(&options)
 	c.Assert(err, chk.IsNil)
-	defer out.Close()
-	blobContents, err := ioutil.ReadAll(out)
+	defer out.Body.Close()
+	blobContents, err := ioutil.ReadAll(out.Body)
 	c.Assert(err, chk.IsNil)
 	c.Assert(blobContents, chk.DeepEquals, chunk1)
 
@@ -110,8 +110,8 @@ func (s *StorageBlobSuite) TestPutAppendBlobSpecialChars(c *chk.C) {
 	options.Range.End = uint64(len(chunk1) + len(chunk2) - 1)
 	out, err = b.GetRange(&options)
 	c.Assert(err, chk.IsNil)
-	defer out.Close()
-	blobContents, err = ioutil.ReadAll(out)
+	defer out.Body.Close()
+	blobContents, err = ioutil.ReadAll(out.Body)
 	c.Assert(err, chk.IsNil)
 	c.Assert(blobContents, chk.DeepEquals, append(chunk1, chunk2...))
 }

--- a/blobserviceclient.go
+++ b/blobserviceclient.go
@@ -96,6 +96,8 @@ func (p ListContainersParameters) getParameters() url.Values {
 	return out
 }
 
+// ResponseInfo includes information related to an Azure storage request
+// (to the request itself, not the operation)
 type ResponseInfo struct {
 	Date      time.Time
 	RequestID string
@@ -128,6 +130,7 @@ func getResponseInfo(h http.Header) (ResponseInfo, error) {
 	return ri, nil
 }
 
+// OriginResponse includes CORS releated response headers
 type OriginResponse struct {
 	AccessControlAllowOrigin      string
 	AccessControlExposeHeaders    string

--- a/blockblob_test.go
+++ b/blockblob_test.go
@@ -25,8 +25,8 @@ func (s *BlockBlobSuite) TestCreateBlockBlobFromReader(c *chk.C) {
 
 	resp, err := b.Get(nil)
 	c.Assert(err, chk.IsNil)
-	gotData, err := ioutil.ReadAll(resp)
-	defer resp.Close()
+	gotData, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
 
 	c.Assert(err, chk.IsNil)
 	c.Assert(gotData, chk.DeepEquals, data)
@@ -128,7 +128,7 @@ func (s *BlockBlobSuite) TestPutEmptyBlockBlob(c *chk.C) {
 
 	c.Assert(b.putSingleBlockBlob([]byte{}), chk.IsNil)
 
-	err := b.GetProperties(nil)
+	_, err := b.GetProperties(nil)
 	c.Assert(err, chk.IsNil)
 	c.Assert(b.Properties.ContentLength, chk.Not(chk.Equals), 0)
 }

--- a/client.go
+++ b/client.go
@@ -87,6 +87,7 @@ type AzureStorageServiceError struct {
 	Reason                    string `xml:"Reason"`
 	StatusCode                int
 	RequestID                 string
+	OtherErrors               string
 }
 
 type odataErrorMessageMessage struct {
@@ -465,8 +466,8 @@ func serviceErrFromStatusCode(code int, status string, requestID string) AzureSt
 }
 
 func (e AzureStorageServiceError) Error() string {
-	return fmt.Sprintf("storage: service returned error: StatusCode=%d, ErrorCode=%s, ErrorMessage=%s, RequestId=%s, QueryParameterName=%s, QueryParameterValue=%s",
-		e.StatusCode, e.Code, e.Message, e.RequestID, e.QueryParameterName, e.QueryParameterValue)
+	return fmt.Sprintf("storage: service returned error: StatusCode=%d, ErrorCode=%s, ErrorMessage=%s, RequestId=%s, QueryParameterName=%s, QueryParameterValue=%s. Other errors encountered: %s",
+		e.StatusCode, e.Code, e.Message, e.RequestID, e.QueryParameterName, e.QueryParameterValue, e.OtherErrors)
 }
 
 // checkRespCode returns UnexpectedStatusError if the given response code is not

--- a/client_test.go
+++ b/client_test.go
@@ -168,8 +168,7 @@ func (s *StorageClientSuite) TestReturnsStorageServiceError_withoutResponseBody(
 	cli := getBlobClient(c)
 	cnt := cli.GetContainerReference("non-existing-container")
 	b := cnt.GetBlobReference("non-existing-blob")
-	err := b.GetProperties(nil)
-
+	_, err := b.GetProperties(nil)
 	c.Assert(err, chk.NotNil)
 	c.Assert(err, chk.FitsTypeOf, AzureStorageServiceError{})
 

--- a/container_test.go
+++ b/container_test.go
@@ -313,7 +313,8 @@ func (s *ContainerSuite) TestListBlobsWithMetadata(c *chk.C) {
 			"Lol":      name,
 			"Rofl_BAZ": "Waz Qux",
 		}
-		c.Assert(b.SetMetadata(nil), chk.IsNil)
+		_, err := b.SetMetadata(nil)
+		c.Assert(err, chk.IsNil)
 		expectMeta[name] = BlobMetadata{
 			"lol":      name,
 			"rofl_baz": "Waz Qux",

--- a/copyblob.go
+++ b/copyblob.go
@@ -129,7 +129,7 @@ func (b *Blob) AbortCopy(copyID string, options *AbortCopyOptions) error {
 // WaitForCopy loops until a BlobCopy operation is completed (or fails with error)
 func (b *Blob) WaitForCopy(copyID string) error {
 	for {
-		err := b.GetProperties(nil)
+		_, err := b.GetProperties(nil)
 		if err != nil {
 			return err
 		}

--- a/copyblob_test.go
+++ b/copyblob_test.go
@@ -35,8 +35,8 @@ func (s *CopyBlobSuite) TestBlobCopy(c *chk.C) {
 	resp, err := dstBlob.Get(nil)
 	c.Assert(err, chk.IsNil)
 
-	b, err := ioutil.ReadAll(resp)
-	defer resp.Close()
+	b, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
 	c.Assert(err, chk.IsNil)
 	c.Assert(b, chk.DeepEquals, body)
 }

--- a/fileserviceclient.go
+++ b/fileserviceclient.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 )
 
 // FileServiceClient contains operations for Microsoft Azure File Service.
@@ -327,35 +326,6 @@ func (f FileServiceClient) getMetadata(path string, res resourceType) (map[strin
 	}
 
 	return getMetadataFromHeaders(headers), nil
-}
-
-// returns a map of custom metadata values from the specified HTTP header
-func getMetadataFromHeaders(header http.Header) map[string]string {
-	metadata := make(map[string]string)
-	for k, v := range header {
-		// Can't trust CanonicalHeaderKey() to munge case
-		// reliably. "_" is allowed in identifiers:
-		// https://msdn.microsoft.com/en-us/library/azure/dd179414.aspx
-		// https://msdn.microsoft.com/library/aa664670(VS.71).aspx
-		// http://tools.ietf.org/html/rfc7230#section-3.2
-		// ...but "_" is considered invalid by
-		// CanonicalMIMEHeaderKey in
-		// https://golang.org/src/net/textproto/reader.go?s=14615:14659#L542
-		// so k can be "X-Ms-Meta-Lol" or "x-ms-meta-lol_rofl".
-		k = strings.ToLower(k)
-		if len(v) == 0 || !strings.HasPrefix(k, strings.ToLower(userDefinedMetadataHeaderPrefix)) {
-			continue
-		}
-		// metadata["lol"] = content of the last X-Ms-Meta-Lol header
-		k = k[len(userDefinedMetadataHeaderPrefix):]
-		metadata[k] = v[len(v)-1]
-	}
-
-	if len(metadata) == 0 {
-		return nil
-	}
-
-	return metadata
 }
 
 //checkForStorageEmulator determines if the client is setup for use with

--- a/pageblob_test.go
+++ b/pageblob_test.go
@@ -23,7 +23,7 @@ func (s *PageBlobSuite) TestPutPageBlob(c *chk.C) {
 	c.Assert(b.PutPageBlob(nil), chk.IsNil)
 
 	// Verify
-	err := b.GetProperties(nil)
+	_, err := b.GetProperties(nil)
 	c.Assert(err, chk.IsNil)
 	c.Assert(b.Properties.ContentLength, chk.Equals, size)
 	c.Assert(b.Properties.BlobType, chk.Equals, BlobTypePage)
@@ -60,8 +60,8 @@ func (s *PageBlobSuite) TestPutPagesUpdate(c *chk.C) {
 	}
 	out, err := b.GetRange(&options)
 	c.Assert(err, chk.IsNil)
-	defer out.Close()
-	blobContents, err := ioutil.ReadAll(out)
+	defer out.Body.Close()
+	blobContents, err := ioutil.ReadAll(out.Body)
 	c.Assert(err, chk.IsNil)
 	c.Assert(blobContents, chk.DeepEquals, append(chunk1, chunk2...))
 
@@ -74,8 +74,8 @@ func (s *PageBlobSuite) TestPutPagesUpdate(c *chk.C) {
 	// Verify contents
 	out, err = b.GetRange(&options)
 	c.Assert(err, chk.IsNil)
-	defer out.Close()
-	blobContents, err = ioutil.ReadAll(out)
+	defer out.Body.Close()
+	blobContents, err = ioutil.ReadAll(out.Body)
 	c.Assert(err, chk.IsNil)
 	c.Assert(blobContents, chk.DeepEquals, append(append(chunk0, chunk1[512:]...), chunk2...))
 }
@@ -112,9 +112,9 @@ func (s *PageBlobSuite) TestPutPagesClear(c *chk.C) {
 	}
 	out, err := b.GetRange(&options)
 	c.Assert(err, chk.IsNil)
-	contents, err := ioutil.ReadAll(out)
+	contents, err := ioutil.ReadAll(out.Body)
 	c.Assert(err, chk.IsNil)
-	defer out.Close()
+	defer out.Body.Close()
 	c.Assert(contents, chk.DeepEquals, append(append(chunk[:512], make([]byte, 512)...), chunk[1024:]...))
 }
 


### PR DESCRIPTION
More complete responses. It includes all request related responses (like API version, request ID and date), and not only the operation related responses (like, let's say, the body in a get blob operation).
Even if the request fails, these response data should be populated.
PTAL @jhendrixMSFT @marstr